### PR TITLE
feat: remove types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
     // "rootDir": "src",
     // Language and Environment
     "target": "ES2017",
-    "types": [
-      "node"
-    ],
     "lib": [
       "ESNext"
     ],


### PR DESCRIPTION
没必要指定 `“types”` 配置，这样会导致 ts 只会加载 @types/node 了，如果装了 @types/mocha 都不会自动加载，使用者还得在 tsconfig 里重新配 types 覆盖原有配置。
